### PR TITLE
Allow Lua Scripts as event callbacks

### DIFF
--- a/editor/gui/file_system_dock.cpp
+++ b/editor/gui/file_system_dock.cpp
@@ -21,7 +21,7 @@ void FileSystemDock::drawFileSystemTree(const FilePath& path)
 			if (ImGui::Selectable(item.filename().string().c_str(), m_OpenedFileName == item.string()))
 			{
 				m_OpenedFileName = item.string();
-				EventManager::GetSingleton()->call("OpenFile", "EditorOpenFile", item);
+				EventManager::GetSingleton()->call("OpenFile", "EditorOpenFile", item.string());
 			}
 		
 			if (ImGui::BeginDragDropSource())

--- a/editor/gui/file_viewer.cpp
+++ b/editor/gui/file_viewer.cpp
@@ -57,7 +57,7 @@ Variant FileViewer::openFile(const Event* event)
 	m_ImageViewer.unload();
 	m_TextViewer.unload();
 
-	m_OpenFilePath = Extract(FilePath, event->getData());
+	m_OpenFilePath = Extract(String, event->getData());
 
 	const String& ext = m_OpenFilePath.extension().string();
 	if (ext == ".wav")

--- a/game/assets/levels/level_0/entities/Cube #2.entity.json
+++ b/game/assets/levels/level_0/entities/Cube #2.entity.json
@@ -5,8 +5,10 @@
             "parent": 1
         },
         "ScriptComponent": {
-            "connections": {},
-            "script": "game\\assets\\scripts\\rotator.lua"
+            "connections": {
+                "newFunction": "NewEvent"
+            },
+            "script": "game\\assets\\scripts\\cube.lua"
         },
         "TransformComponent": {
             "position": {

--- a/game/assets/scripts/cube.lua
+++ b/game/assets/scripts/cube.lua
@@ -1,16 +1,4 @@
 function onBegin(entity)
-    v1 = Rootex.Vector2.new(1,1)
-    v2 = Rootex.Vector2.new(1,1)
-    print((v1 + v2).x)
-    print(v1.x)
-    print(v2.x)
-    text = entity:getTextVisual2D()
-    print(text)
-    number = 0
-    Rootex.CallEvent("MyEvent", "CubeEvent")
-    Rootex.CallEvent("MyEvent", "CubeEvent")
-    Rootex.CallEvent("MyEvent", "CubeEvent")
-    Rootex.CallEvent("MyEvent", "CubeEvent")
 end
 
 function onUpdate(delta, entity)
@@ -18,8 +6,8 @@ function onUpdate(delta, entity)
     text:setText(tostring(number))
 end
 
-function newFunction()
-    print("newFunction was called!")
+function newFunction(event)
+    print(event:getData())
 end
 
 function onEnd(entity)

--- a/rootex/common/types.h
+++ b/rootex/common/types.h
@@ -59,7 +59,7 @@ namespace ColorPresets = DirectX::Colors;
 #include <variant>
 typedef Vector<std::variant<bool, int, char, float, String, Vector2, Vector3, Vector4, Matrix>> VariantVector;
 class Entity;
-using Variant = std::variant<bool, int, char, float, String, FilePath, Vector2, Vector3, Vector4, Matrix, VariantVector, Ref<Entity>, Vector<String>>;
+using Variant = std::variant<bool, int, char, float, String, Vector2, Vector3, Vector4, Matrix, VariantVector, Ref<Entity>, Vector<String>>;
 #define Extract(TypeName, variant) std::get<TypeName>((variant))
 
 #include <functional>
@@ -70,7 +70,6 @@ using Function = std::function<T>;
 namespace JSON = nlohmann;
 
 #include "imgui.h"
-#include "sol/sol.hpp"
 
 // target Windows 7 or later
 #define _WIN32_WINNT 0x0601

--- a/rootex/core/event.h
+++ b/rootex/core/event.h
@@ -18,6 +18,6 @@ public:
 	~Event() = default;
 	
 	const String& getName() const { return m_Name; };
-	const Type& getEventType() const { return m_Type; };
+	const Type& getType() const { return m_Type; };
 	const Variant& getData() const { return m_Data; }
 };

--- a/rootex/core/event_manager.cpp
+++ b/rootex/core/event_manager.cpp
@@ -30,11 +30,9 @@ void EventManager::removeEvent(const Event::Type& event)
 	m_EventListeners.erase(event);
 }
 
-Variant EventManager::returnCall(const String& eventName, const Event::Type& eventType, const Variant& data)
+Variant EventManager::returnCall(const Event& event)
 {
-	bool processed = false;
-	Event event(eventName, eventType, data);
-	auto&& findIt = m_EventListeners.find(event.getEventType());
+	auto&& findIt = m_EventListeners.find(event.getType());
 
 	if (findIt != m_EventListeners.end())
 	{
@@ -43,11 +41,16 @@ Variant EventManager::returnCall(const String& eventName, const Event::Type& eve
 	return false;
 }
 
-void EventManager::call(const String& eventName, const Event::Type& eventType, const Variant& data)
+Variant EventManager::returnCall(const String& eventName, const Event::Type& eventType, const Variant& data)
+{
+	Event event(eventName, eventType, data);
+	return returnCall(event);
+}
+
+void EventManager::call(const Event& event)
 {
 	bool processed = false;
-	Event event(eventName, eventType, data);
-	auto&& findIt = m_EventListeners.find(event.getEventType());
+	auto&& findIt = m_EventListeners.find(event.getType());
 
 	if (findIt != m_EventListeners.end())
 	{
@@ -61,16 +64,20 @@ void EventManager::call(const String& eventName, const Event::Type& eventType, c
 	}
 }
 
-void EventManager::deferredCall(const String& eventName, const Event::Type& eventType, const Variant& data)
+void EventManager::call(const String& eventName, const Event::Type& eventType, const Variant& data)
 {
-	Ref<Event> event(new Event(eventName, eventType, data));
+	Event event(eventName, eventType, data);
+	call(event);
+}
 
+void EventManager::deferredCall(Ref<Event> event)
+{
 	if (!(m_ActiveQueue >= 0 && m_ActiveQueue < EVENTMANAGER_NUM_QUEUES))
 	{
 		WARN("Event left unhandled: " + event->getName());
 	}
 
-	auto&& findIt = m_EventListeners.find(event->getEventType());
+	auto&& findIt = m_EventListeners.find(event->getType());
 	if (findIt != m_EventListeners.end())
 	{
 		m_Queues[m_ActiveQueue].push_back(event);
@@ -80,6 +87,12 @@ void EventManager::deferredCall(const String& eventName, const Event::Type& even
 	{
 		WARN("Event left unhandled: " + event->getName());
 	}
+}
+
+void EventManager::deferredCall(const String& eventName, const Event::Type& eventType, const Variant& data)
+{
+	Ref<Event> event(new Event(eventName, eventType, data));
+	deferredCall(event);
 }
 
 bool EventManager::dispatchDeferred(unsigned long maxMillis)
@@ -92,7 +105,7 @@ bool EventManager::dispatchDeferred(unsigned long maxMillis)
 	{
 		Ref<Event> event = m_Queues[queueToProcess].front();
 		m_Queues[queueToProcess].erase(m_Queues[queueToProcess].begin());
-		const Event::Type eventType = event->getEventType();
+		const Event::Type eventType = event->getType();
 
 		auto findIt = m_EventListeners.find(eventType);
 		if (findIt != m_EventListeners.end())

--- a/rootex/core/event_manager.h
+++ b/rootex/core/event_manager.h
@@ -44,8 +44,11 @@ public:
 	bool addListener(const Event::Type& type, EventHandlingFunction instance);
 	bool removeListener(const EventHandlingFunction handlerName, const Event::Type& type);
 
+	Variant returnCall(const Event& event);
 	Variant returnCall(const String& eventName, const Event::Type& eventType, const Variant& data);
+	void call(const Event& event);
 	void call(const String& eventName, const Event::Type& eventType, const Variant& data);
+	void deferredCall(Ref<Event> event);
 	void deferredCall(const String& eventName, const Event::Type& eventType, const Variant& data);
 	bool dispatchDeferred(unsigned long maxMillis = Infinite);
 

--- a/rootex/core/resource_loader.cpp
+++ b/rootex/core/resource_loader.cpp
@@ -272,7 +272,6 @@ void ResourceLoader::ReloadResourceData(const String& path)
 		if (resData->getPath() == path)
 		{
 			*resData->getRawData() = buffer;
-			break;
 		}
 	}
 }

--- a/rootex/framework/components/music_component.cpp
+++ b/rootex/framework/components/music_component.cpp
@@ -90,7 +90,7 @@ void MusicComponent::draw()
 
 	if (ImGui::Button("Audio File"))
 	{
-		EventManager::GetSingleton()->call("OpenScript", "EditorOpenFile", m_AudioFile->getPath());
+		EventManager::GetSingleton()->call("OpenScript", "EditorOpenFile", m_AudioFile->getPath().string());
 	}
 	ImGui::EndGroup();
 
@@ -111,5 +111,7 @@ void MusicComponent::draw()
 		}
 		ImGui::EndDragDropTarget();
 	}
+
+	ImGui::Checkbox("Play on start", &m_IsPlayOnStart);
 }
 #endif // ROOTEX_EDITOR

--- a/rootex/framework/components/script_component.h
+++ b/rootex/framework/components/script_component.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "component.h"
+#include "event_manager.h"
 #include "script/interpreter.h"
 
 class ScriptComponent : public Component
@@ -29,7 +30,7 @@ public:
 	virtual bool setup() override;
 
 	void connect(const String& function, const String& eventType);
-	void call(const String& function);
+	void call(const String& function, const Event* event);
 	void onBegin();
 	virtual void onUpdate(float deltaMilliSeconds);
 	void onEnd();
@@ -39,7 +40,7 @@ public:
 	virtual String getName() const override { return "ScriptComponent"; }
 	virtual JSON::json getJSON() const override;
 
-	void setScript(LuaTextResourceFile* newScript) { m_ScriptFile = newScript; }
+	void setScript(LuaTextResourceFile* newScript);
 
 #ifdef ROOTEX_EDITOR
 	virtual void draw();

--- a/rootex/framework/components/short_music_component.cpp
+++ b/rootex/framework/components/short_music_component.cpp
@@ -89,7 +89,7 @@ void ShortMusicComponent::draw()
 
 	if (ImGui::Button("Audio File"))
 	{
-		EventManager::GetSingleton()->call("OpenScript", "EditorOpenFile", m_AudioFile->getPath());
+		EventManager::GetSingleton()->call("OpenScript", "EditorOpenFile", m_AudioFile->getPath().string());
 	}
 	ImGui::EndGroup();
 

--- a/rootex/framework/components/visual/visual_component.cpp
+++ b/rootex/framework/components/visual/visual_component.cpp
@@ -228,7 +228,7 @@ void VisualComponent::draw()
 
 	if (ImGui::Button("Visual Model"))
 	{
-		EventManager::GetSingleton()->call("OpenScript", "EditorOpenFile", m_Attributes.m_VisualModelResourceFile->getPath());
+		EventManager::GetSingleton()->call("OpenScript", "EditorOpenFile", m_Attributes.m_VisualModelResourceFile->getPath().string());
 	}
 	ImGui::EndGroup();
 

--- a/rootex/script/interpreter.h
+++ b/rootex/script/interpreter.h
@@ -7,6 +7,25 @@
 #define SOL_ALL_SAFETIES_ON	1
 #define SOL_USING_CXX_LUA 1
 #define SOL_PRINT_ERRORS 1
+
+#if (defined(__cplusplus) && __cplusplus >= 201703L) \
+    || (defined(_MSC_VER) && _MSC_VER > 1900 && ((defined(_HAS_CXX17) && _HAS_CXX17 == 1) || (defined(_MSVC_LANG) && (_MSVC_LANG > 201402L))))
+#endif // C++17 features check
+#if defined(__cpp_noexcept_function_type) || ((defined(_MSC_VER) && _MSC_VER > 1911) && (defined(_MSVC_LANG) && ((_MSVC_LANG >= 201403L))))
+#ifndef SOL_NOEXCEPT_FUNCTION_TYPE
+#define SOL_NOEXCEPT_FUNCTION_TYPE 1
+#endif // noexcept is part of a function's type
+#endif // compiler-specific checks
+#if defined(__clang__) && defined(__APPLE__)
+#if defined(__has_include)
+#if __has_include(<variant>)
+#define SOL_STD_VARIANT 1
+#endif // has include nonsense
+#endif // __has_include
+#else
+#define SOL_STD_VARIANT 1
+#endif // Clang screws up variant
+
 #include "sol/sol.hpp"
 
 class LuaInterpreter


### PR DESCRIPTION
Adds the ability to set Lua functions as callback and channel the event object to the Lua function in a variant, which sol3 is smart enough to unpack to the original type of the event data before calling the lua function with the event object argument