### PR TITLE
Fix gizmo and CPU particles not using the local transform of children

### DIFF
--- a/editor/gui/viewport_dock.cpp
+++ b/editor/gui/viewport_dock.cpp
@@ -115,8 +115,8 @@ void ViewportDock::draw()
 				Matrix view = RenderSystem::GetSingleton()->getCamera()->getViewMatrix();
 				Matrix proj = RenderSystem::GetSingleton()->getCamera()->getProjectionMatrix();
 
-				Matrix matrix = openedEntity->getComponent<TransformComponent>()->getParentAbsoluteTransform();
-				static Matrix deltaMatrix = Matrix::Identity;
+				Matrix matrix = openedEntity->getComponent<TransformComponent>()->getAbsoluteTransform();
+				Matrix deltaMatrix = Matrix::CreateTranslation(0.0f, 0.0f, 0.0f);
 				ImGuizmo::Manipulate(
 				    &view.m[0][0],
 				    &proj.m[0][0],

--- a/rootex/framework/components/visual/cpu_particles_visual_component.h
+++ b/rootex/framework/components/visual/cpu_particles_visual_component.h
@@ -22,12 +22,11 @@ class CPUParticlesVisualComponent : public ModelVisualComponent
 	
 	struct Particle
 	{
-		Vector3 m_Position;
+		Matrix m_Transform;
 		Vector3 m_Velocity;
 		Quaternion m_AngularVelocity;
 		Color m_ColorBegin;
 		Color m_ColorEnd;
-		Quaternion m_Rotation;
 		float m_SizeBegin;
 		float m_SizeEnd;
 		float m_LifeTime;

--- a/rootex/framework/components/visual/model_visual_component.cpp
+++ b/rootex/framework/components/visual/model_visual_component.cpp
@@ -73,7 +73,6 @@ bool ModelVisualComponent::preRender()
 	if (m_TransformComponent)
 	{
 		RenderSystem::GetSingleton()->pushMatrix(getTransform());
-		m_TransformComponent->m_TransformBuffer.m_ParentAbsoluteTransform = RenderSystem::GetSingleton()->getTopMatrix();
 	}
 	else
 	{


### PR DESCRIPTION
Also changes CPU particles to use transforms instead of individual position and rotation values. This helps the gizmo to pick the correct transform value from the particle components