### PR TITLE
Add RmlUi events through EventManager

### DIFF
--- a/rootex/assets/rml/demo.rml
+++ b/rootex/assets/rml/demo.rml
@@ -42,6 +42,6 @@
 	<body>
 		<p id="transition_test"> This is a sample </p>
 		<br />
-		<img src="../rootex.png" width=100 height=100 />
+		<img onclick="UIImageClicked" src="../rootex.png" width=100 height=100 />
 	</body>
 </rml>

--- a/rootex/common/types.h
+++ b/rootex/common/types.h
@@ -90,7 +90,7 @@ namespace ColorPresets = DirectX::Colors;
 /// Vector of std::variant of bool, int, char, float, String, Vector2, Vector3, Vector4, Matrix
 typedef Vector<std::variant<bool, int, char, float, String, Vector2, Vector3, Vector4, Matrix>> VariantVector;
 class Entity;
-/// std::variant of bool, int, char, float, String, Vector2, Vector3, Vector4, Matrix VariantVector, Ref<Entity>, Vector<String>
+/// A variant able to hold multiple kinds of data, one at a time.
 using Variant = std::variant<bool, int, char, float, String, Vector2, Vector3, Vector4, Matrix, VariantVector, Ref<Entity>, Vector<String>>;
 /// Extract the value of type TypeName from a Variant
 #define Extract(TypeName, variant) std::get<TypeName>((variant))

--- a/rootex/framework/systems/ui_system.cpp
+++ b/rootex/framework/systems/ui_system.cpp
@@ -39,7 +39,23 @@ bool CustomSystemInterface::LogMessage(Rml::Core::Log::Type type, const String& 
 	return true;
 }
 
+Rml::Core::EventListener* EventListenerInstancer::InstanceEventListener(const String& value, Rml::Core::Element* element)
+{
+	return new EventListener(value);
+}
+
+EventListener::EventListener(const Event::Type& eventType)
+    : m_EventType(eventType)
+{
+}
+
+void EventListener::ProcessEvent(Rml::Core::Event& event)
+{
+	EventManager::GetSingleton()->call("UIEventProxy", m_EventType, event.GetType());
+}
+
 UISystem::UISystem()
+    : m_Context(nullptr)
 {
 	BIND_EVENT_MEMBER_FUNCTION("UISystemEnableDebugger", UISystem::enableDebugger);
 	BIND_EVENT_MEMBER_FUNCTION("UISystemDisableDebugger", UISystem::disableDebugger);
@@ -82,7 +98,6 @@ Rml::Core::ElementDocument* UISystem::loadDocument(const String& path)
 	{
 		WARN("Could not load document: " + path);
 	}
-
 	return document;
 }
 
@@ -103,9 +118,15 @@ void UISystem::initialize(int width, int height)
 		ERR("Could not initialize RmlUi UI rendering library");
 	}
 	Rml::Controls::Initialise();
+	
 	loadFont("rootex/assets/fonts/Lato-Regular.ttf");
+	
 	m_Context = Rml::Core::CreateContext("default", Rml::Core::Vector2i(width, height));
+	
 	Rml::Debugger::Initialise(m_Context);
+	
+	Rml::Core::Factory::RegisterEventListenerInstancer(&s_EventListenerInstancer);
+
 	InputInterface::Initialise();
 	InputInterface::SetContext(m_Context);
 }

--- a/rootex/framework/systems/ui_system.h
+++ b/rootex/framework/systems/ui_system.h
@@ -14,8 +14,26 @@ class CustomSystemInterface : public Rml::Core::SystemInterface
 	virtual bool LogMessage(Rml::Core::Log::Type type, const String& message) override;
 };
 
+class EventListener : public Rml::Core::EventListener
+{
+	Event::Type m_EventType;
+
+public:
+	EventListener(const Event::Type& eventType);
+
+	virtual void ProcessEvent(Rml::Core::Event& event) override;
+};
+
+class EventListenerInstancer : public Rml::Core::EventListenerInstancer
+{
+public:
+	virtual Rml::Core::EventListener* InstanceEventListener(const String& value, Rml::Core::Element* element) override;
+};
+
 class UISystem : public System
 {
+	static inline EventListenerInstancer s_EventListenerInstancer;
+
 	Ptr<CustomSystemInterface> m_RmlSystemInterface;
 	Ptr<CustomRenderInterface> m_RmlRenderInterface;
 	Rml::Core::Context* m_Context;


### PR DESCRIPTION
Put all RmlUi UI events through Rootex's EventManager so that events can be sent around the engine and also inside Lua scripts.

Needs #210 