### PR TITLE
Fix wrong size interpolation in particles and more perf improvements

### DIFF
--- a/game/assets/materials/Condensation.rmat
+++ b/game/assets/materials/Condensation.rmat
@@ -1,22 +1,20 @@
 {
-    "affectedBySky": true,
+    "affectedBySky": false,
     "color": {
         "a": 1.0,
-        "b": 0.7065566182136536,
-        "g": 0.7065566182136536,
-        "r": 0.7065637111663818
+        "b": 0.9998999834060669,
+        "g": 0.9998999834060669,
+        "r": 1.0
     },
-    "imageFile": "rootex/assets/white.png",
+    "imageFile": "game/assets/sponza/textures/spnza_bricks_a_diff.png",
     "isAlpha": true,
-    "isLit": true,
+    "isLit": false,
     "isNormal": true,
     "lightmapImageFile": "rootex/assets/white.png",
-    "normalImageFile": "game/assets/test/WaterDropletsMixedBubbled001_NRM16_1K.png",
-    "reflectivity": 1.0,
+    "normalImageFile": "game/assets/sponza/textures/spnza_bricks_a_ddn.png",
+    "reflectivity": 0.0,
     "refractionConstant": 0.0,
-    "refractivity": 0.6499999761581421,
-    "specularImageFile": "rootex/assets/white.png",
-    "specularIntensity": 1.0,
-    "specularPower": 100.0,
+    "refractivity": 0.0,
+    "specularImageFile": "game/assets/sponza/textures/spnza_bricks_a_spec.png",
     "type": "BasicMaterial"
 }

--- a/game/assets/materials/test_particles.rmat
+++ b/game/assets/materials/test_particles.rmat
@@ -1,13 +1,13 @@
 {
     "affectedBySky": false,
-    "imageFile": "rootex/assets/white.png",
+    "imageFile": "game/assets/sponza/textures/spnza_bricks_a_diff.png",
     "isAlpha": false,
     "isLit": false,
     "isNormal": true,
-    "normalImageFile": "game/assets/test/WaterDropletsMixedBubbled001_NRM16_1K.png",
-    "reflectivity": 0.0,
+    "normalImageFile": "game/assets/sponza/textures/spnza_bricks_a_ddn.png",
+    "reflectivity": 1.0,
     "refractionConstant": 0.9200000166893005,
-    "refractivity": 0.0,
-    "specularImageFile": "rootex/assets/white.png",
+    "refractivity": 1.0,
+    "specularImageFile": "game/assets/sponza/textures/spnza_bricks_a_spec.png",
     "type": "ParticlesMaterial"
 }

--- a/game/assets/scenes/mesh_collision.scene.json
+++ b/game/assets/scenes/mesh_collision.scene.json
@@ -185,75 +185,6 @@
                     "ID": 10,
                     "children": [
                         {
-                            "ID": 12,
-                            "children": [],
-                            "entity": {
-                                "Entity": {
-                                    "script": null
-                                },
-                                "components": {
-                                    "PointLightComponent": {
-                                        "ambientColor": {
-                                            "a": 1.0,
-                                            "b": 0.14293168485164642,
-                                            "g": 0.7876448035240173,
-                                            "r": 0.2398735135793686
-                                        },
-                                        "attConst": -0.8849999904632568,
-                                        "attLin": 2.0799999237060547,
-                                        "attQuad": -0.9800000190734863,
-                                        "diffuseColor": {
-                                            "a": 1.0,
-                                            "b": 0.06887196749448776,
-                                            "g": 0.06887196749448776,
-                                            "r": 0.8494208455085754
-                                        },
-                                        "diffuseIntensity": 8.399999618530273,
-                                        "range": 5.099999904632568
-                                    },
-                                    "TransformComponent": {
-                                        "boundingBox": {
-                                            "center": {
-                                                "x": 0.0,
-                                                "y": 0.0,
-                                                "z": 0.0
-                                            },
-                                            "extents": {
-                                                "x": 0.5,
-                                                "y": 0.5,
-                                                "z": 0.5
-                                            }
-                                        },
-                                        "position": {
-                                            "x": 2.288818359375e-05,
-                                            "y": -4.57763671875e-05,
-                                            "z": 1.1444091796875e-05
-                                        },
-                                        "rotation": {
-                                            "w": 0.0,
-                                            "x": -0.0,
-                                            "y": 0.0,
-                                            "z": -0.0
-                                        },
-                                        "scale": {
-                                            "x": 33.333335876464844,
-                                            "y": 33.333335876464844,
-                                            "z": 33.333335876464844
-                                        }
-                                    }
-                                }
-                            },
-                            "file": "game/assets/scenes/point_light.scene.json",
-                            "name": "Point Light",
-                            "settings": {
-                                "camera": 1,
-                                "inputSchemes": {},
-                                "listener": 1,
-                                "preloads": [],
-                                "startScheme": ""
-                            }
-                        },
-                        {
                             "ID": 13,
                             "children": [],
                             "entity": {
@@ -357,7 +288,77 @@
                         },
                         {
                             "ID": 16,
-                            "children": [],
+                            "children": [
+                                {
+                                    "ID": 12,
+                                    "children": [],
+                                    "entity": {
+                                        "Entity": {
+                                            "script": null
+                                        },
+                                        "components": {
+                                            "PointLightComponent": {
+                                                "ambientColor": {
+                                                    "a": 1.0,
+                                                    "b": 0.9999899864196777,
+                                                    "g": 0.9999904036521912,
+                                                    "r": 1.0
+                                                },
+                                                "attConst": 2.555000066757202,
+                                                "attLin": 2.009999990463257,
+                                                "attQuad": 0.11999999731779099,
+                                                "diffuseColor": {
+                                                    "a": 1.0,
+                                                    "b": 0.23480723798274994,
+                                                    "g": 0.46073639392852783,
+                                                    "r": 0.5484949946403503
+                                                },
+                                                "diffuseIntensity": 25.700000762939453,
+                                                "range": 4.199999809265137
+                                            },
+                                            "TransformComponent": {
+                                                "boundingBox": {
+                                                    "center": {
+                                                        "x": 0.0,
+                                                        "y": 0.0,
+                                                        "z": 0.0
+                                                    },
+                                                    "extents": {
+                                                        "x": 0.5,
+                                                        "y": 0.5,
+                                                        "z": 0.5
+                                                    }
+                                                },
+                                                "position": {
+                                                    "x": 0.0,
+                                                    "y": 0.0,
+                                                    "z": 0.0
+                                                },
+                                                "rotation": {
+                                                    "w": 1.0,
+                                                    "x": -0.0,
+                                                    "y": 0.0,
+                                                    "z": -0.0
+                                                },
+                                                "scale": {
+                                                    "x": 4.175970554351807,
+                                                    "y": 4.176144123077393,
+                                                    "z": 4.177108287811279
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "file": "game/assets/scenes/point_light.scene.json",
+                                    "name": "Point Light",
+                                    "settings": {
+                                        "camera": 1,
+                                        "inputSchemes": {},
+                                        "listener": 1,
+                                        "preloads": [],
+                                        "startScheme": ""
+                                    }
+                                }
+                            ],
                             "entity": {
                                 "Entity": {
                                     "script": null
@@ -365,11 +366,11 @@
                                 "components": {
                                     "CPUParticlesComponent": {
                                         "affectingStaticLights": [],
-                                        "emitMode": 0,
+                                        "emitMode": 3,
                                         "emitterDimensions": {
-                                            "x": 10.0,
-                                            "y": 10.0,
-                                            "z": 10.0
+                                            "x": 0.36000001430511475,
+                                            "y": 1.0,
+                                            "z": 1.0
                                         },
                                         "isVisible": true,
                                         "materialOverrides": {
@@ -377,31 +378,32 @@
                                         },
                                         "materialPath": "game/assets/materials/test_particles.rmat",
                                         "particleTemplate": {
-                                            "angularVelocityVariation": 100.0,
+                                            "angularVelocityVariation": 0.0,
                                             "colorBegin": {
                                                 "a": 1.0,
-                                                "b": 0.05882352963089943,
-                                                "g": 0.9960784316062927,
-                                                "r": 0.9921568632125854
+                                                "b": 0.9999899864196777,
+                                                "g": 0.9999899864196777,
+                                                "r": 1.0
                                             },
                                             "colorEnd": {
                                                 "a": 1.0,
-                                                "b": 0.0,
-                                                "g": 1.0,
-                                                "r": 0.0
+                                                "b": 1.0,
+                                                "g": 0.9999929666519165,
+                                                "r": 0.9999899864196777
                                             },
-                                            "lifeTime": 10.0,
-                                            "sizeBegin": 1.0,
-                                            "sizeEnd": 1.0,
-                                            "sizeVariation": 4.070000171661377,
+                                            "lifeTime": 1.1100000143051147,
+                                            "rotationVariation": 2.565634250640869,
+                                            "sizeBegin": 0.20000000298023224,
+                                            "sizeEnd": 0.0,
+                                            "sizeVariation": 0.23999999463558197,
                                             "velocity": {
                                                 "x": 0.0,
                                                 "y": 0.0,
                                                 "z": 0.0
                                             },
-                                            "velocityVariation": 17.0
+                                            "velocityVariation": 0.1599999964237213
                                         },
-                                        "poolSize": 500,
+                                        "poolSize": 486,
                                         "renderPass": 1,
                                         "resFile": "rootex/assets/cube.obj"
                                     },
@@ -424,15 +426,15 @@
                                             "z": 0.0
                                         },
                                         "rotation": {
-                                            "w": 0.0,
+                                            "w": 1.0,
                                             "x": -0.0,
                                             "y": 0.0,
                                             "z": -0.0
                                         },
                                         "scale": {
-                                            "x": 4.53000020980835,
-                                            "y": 4.53000020980835,
-                                            "z": 4.53000020980835
+                                            "x": 1.0000008344650269,
+                                            "y": 1.0000008344650269,
+                                            "z": 1.0000008344650269
                                         }
                                     }
                                 }
@@ -463,7 +465,7 @@
                                 "affectingStaticLights": [],
                                 "isVisible": true,
                                 "materialOverrides": {
-                                    "rootex/assets/materials/default.rmat": "game/assets/materials/column_a.rmat"
+                                    "rootex/assets/materials/default.rmat": "game/assets/materials/Condensation.rmat"
                                 },
                                 "renderPass": 1,
                                 "resFile": "game/assets/test/sphere.obj"
@@ -486,7 +488,7 @@
                                 "isKinematic": false,
                                 "isMoveable": true,
                                 "isSleepable": false,
-                                "material": 2,
+                                "material": 1,
                                 "radius": 0.6000000238418579,
                                 "volume": 0.904778778553009
                             },
@@ -504,15 +506,15 @@
                                     }
                                 },
                                 "position": {
-                                    "x": 2.500000476837158,
-                                    "y": 3.799999713897705,
+                                    "x": 2.1957595348358154,
+                                    "y": 5.5589518547058105,
                                     "z": -12.100000381469727
                                 },
                                 "rotation": {
-                                    "w": 0.0,
-                                    "x": 0.0,
+                                    "w": 1.0,
+                                    "x": -0.0,
                                     "y": 0.0,
-                                    "z": 0.0
+                                    "z": -0.0
                                 },
                                 "scale": {
                                     "x": 0.030000140890479088,

--- a/imgui.ini
+++ b/imgui.ini
@@ -170,13 +170,13 @@ Size=721,597
 Collapsed=0
 
 [Window][Load Scene]
-Pos=1113,617
+Pos=1114,617
 Size=30,58
 Collapsed=0
 
 [Window][Save]
-Pos=1205,625
-Size=237,110
+Pos=1260,625
+Size=303,110
 Collapsed=0
 
 [Window][Style Editor]

--- a/rootex/framework/components/transform_component.h
+++ b/rootex/framework/components/transform_component.h
@@ -20,10 +20,18 @@ private:
 	TransformBuffer m_TransformBuffer;
 
 	Matrix m_ParentAbsoluteTransform;
+
+	Matrix m_AbsoluteTransform;
+	Vector3 m_AbsolutePosition;
+	Quaternion m_AbsoluteRotation;
+	Vector3 m_AbsoluteScale;
+	bool m_IsAbsoluteTransformDirty = true;
+
 	bool m_LockScale = false;
 
 	const TransformBuffer* getTransformBuffer() const { return &m_TransformBuffer; };
 
+	void updateAbsoluteTransformValues();
 	void updateTransformFromPositionRotationScale();
 	void updatePositionRotationScaleFromTransform(Matrix& transform);
 
@@ -54,13 +62,19 @@ public:
 	void addRotation(const Quaternion& applyTransform);
 
 	Vector3 getPosition() const { return m_TransformBuffer.m_Position; }
-	BoundingBox getWorldSpaceBounds() const;
 	Quaternion getRotation() const { return m_TransformBuffer.m_Rotation; };
 	const Vector3& getScale() const { return m_TransformBuffer.m_Scale; }
 	const Matrix& getLocalTransform() const { return m_TransformBuffer.m_Transform; }
 	Matrix getRotationPosition() const { return Matrix::CreateFromQuaternion(m_TransformBuffer.m_Rotation) * Matrix::CreateTranslation(m_TransformBuffer.m_Position) * m_ParentAbsoluteTransform; }
-	Matrix getAbsoluteTransform() const { return m_TransformBuffer.m_Transform * m_ParentAbsoluteTransform; }
 	Matrix getParentAbsoluteTransform() const { return m_ParentAbsoluteTransform; }
+
+	BoundingBox getWorldSpaceBounds();
+
+	Matrix getAbsoluteTransform();
+	Vector3 getAbsolutePosition();
+	Quaternion getAbsoluteRotation();
+	Vector3 getAbsoluteScale();
+
 	ComponentID getComponentID() const override { return s_ID; }
 	virtual const char* getName() const override { return "TransformComponent"; }
 	virtual JSON::json getJSON() const override;

--- a/rootex/framework/components/visual/cpu_particles_component.h
+++ b/rootex/framework/components/visual/cpu_particles_component.h
@@ -3,7 +3,7 @@
 #include "core/renderer/materials/particles_material.h"
 #include "model_component.h"
 
-#define MAX_PARTICLES 50000
+#define MAX_PARTICLES 5000
 
 struct ParticleTemplate
 {
@@ -11,6 +11,7 @@ struct ParticleTemplate
 	Color colorBegin = ColorPresets::Red;
 	Color colorEnd = ColorPresets::Blue;
 	float velocityVariation = 10.0f;
+	float rotationVariation = DirectX::XM_PI;
 	float angularVelocityVariation = 0.5f;
 	float sizeBegin = 0.1f;
 	float sizeEnd = 0.0f;
@@ -29,7 +30,6 @@ class CPUParticlesComponent : public ModelComponent
 
 	struct Particle
 	{
-		bool isActive = false;
 		float sizeBegin;
 		float sizeEnd;
 		float lifeTime;
@@ -38,23 +38,32 @@ class CPUParticlesComponent : public ModelComponent
 		Color colorEnd;
 		Vector3 velocity;
 		Vector3 angularVelocity;
+
+		// Not for use outside
+		Vector3 position;
+		Quaternion rotation;
+		Vector3 scale;
 	};
 
 	ParticleTemplate m_ParticleTemplate;
 	Vector<Particle> m_ParticlePool;
 	Ref<ParticlesMaterial> m_ParticlesMaterial;
 	size_t m_PoolIndex;
-	int m_EmitRate;
+	float m_EmitRate;
 
 	enum class EmitMode : int
 	{
 		Point = 0,
 		Square = 1,
-		Cube = 2
+		Cube = 2,
+		Sphere = 3,
+		End
 	};
 
 	EmitMode m_CurrentEmitMode;
 	Vector3 m_EmitterDimensions;
+
+	float m_EmitCount = 0;
 
 	friend class ECSFactory;
 


### PR DESCRIPTION
Re-fixes #399 with a better approach.

Adds a small perf improvement that the `TransformComponent` will now only recalculate absolute transforms if the underlying local data has been changed, thus reducing redundant operations being made before