### PR TITLE
autosave toggle in editor and off in game

### DIFF
--- a/editor/editor_application.cpp
+++ b/editor/editor_application.cpp
@@ -68,14 +68,13 @@ void EditorApplication::setGameMode(bool enabled)
 	InputSystem::GetSingleton()->loadSchemes(m_ApplicationSettings->getJSON()["systems"]["InputSystem"]["inputSchemes"]);
 	InputSystem::GetSingleton()->pushScheme(m_ApplicationSettings->getJSON()["systems"]["InputSystem"]["startScheme"]);
 	InputInterface::GetSingleton()->m_IsEnabled = enabled;
-	m_IsAutoSave = !enabled;
 
 	EventManager::GetSingleton()->call(EditorEvents::EditorReset);
 }
 
 void EditorApplication::process(float deltaMilliseconds)
 {
-	if (m_IsAutoSave && ((m_ApplicationTimer.Now() - m_PointAtLast10Second).count()) * NS_TO_MS * MS_TO_S > m_AutoSaveDurationS)
+	if (((m_ApplicationTimer.Now() - m_PointAtLast10Second).count()) * NS_TO_MS * MS_TO_S > m_AutoSaveDurationS)
 	{
 		EventManager::GetSingleton()->call(EditorEvents::EditorAutoSave);
 		m_PointAtLast10Second = m_ApplicationTimer.Now();

--- a/editor/editor_application.h
+++ b/editor/editor_application.h
@@ -8,7 +8,6 @@ class EditorApplication : public Application
 	static void SetSingleton(EditorApplication* app);
 
 	unsigned int m_AutoSaveDurationS = 300.0f;
-	bool m_IsAutoSave = true;
 	TimePoint m_PointAtLast10Second;
 	FrameTimer m_FrameTimer;
 

--- a/editor/editor_system.cpp
+++ b/editor/editor_system.cpp
@@ -458,6 +458,8 @@ void EditorSystem::drawDefaultUI(float deltaMilliseconds)
 			}
 			if (ImGui::BeginMenu("Scene"))
 			{
+				ImGui::Checkbox("Autosave", &m_Autosave);
+
 				if (SceneLoader::GetSingleton()->getCurrentScene())
 				{
 					SceneLoader::GetSingleton()->getCurrentScene()->getSettings().draw();
@@ -859,9 +861,14 @@ Variant EditorSystem::saveAll(const Event* event)
 
 Variant EditorSystem::autoSave(const Event* event)
 {
-	PRINT("Auto-saving current scene...");
-	saveAll(nullptr);
-	return true;
+	if (m_Autosave && !(m_Toolbar->getSettings().m_InEditorPlaying))
+	{
+		PRINT("Auto-saving current scene...");
+		saveAll(nullptr);
+		return true;
+	}
+
+	return false;
 }
 
 Variant EditorSystem::saveBeforeQuit(const Event* event)

--- a/editor/editor_system.h
+++ b/editor/editor_system.h
@@ -32,6 +32,7 @@ class EditorSystem : public System
 	unsigned int m_EditorStyleVarPushCount;
 	bool m_WireframeMode = false;
 	bool m_WorldMode = true;
+	bool m_Autosave = false;
 
 	ImFont* m_EditorFont;
 	ImFont* m_EditorFontItalic;

--- a/editor/gui/toolbar_dock.cpp
+++ b/editor/gui/toolbar_dock.cpp
@@ -13,7 +13,7 @@
 
 Variant ToolbarDock::disablePlayInEditor(const Event* e)
 {
-	m_InEditorPlaying = false;
+	m_ToolbarDockSettings.m_InEditorPlaying = false;
 	EditorApplication::GetSingleton()->setGameMode(false);
 	if (!m_StartPlayingScene.empty())
 	{
@@ -48,7 +48,7 @@ void ToolbarDock::draw(float deltaMilliseconds)
 					"Play Game"
 				};
 
-				if (m_InEditorPlaying)
+				if (m_ToolbarDockSettings.m_InEditorPlaying)
 				{
 					ImColor lightErrorColor = EditorSystem::GetSingleton()->getFatalColor();
 					lightErrorColor.Value.x *= 0.8f;
@@ -67,7 +67,7 @@ void ToolbarDock::draw(float deltaMilliseconds)
 						switch (playModeSelected)
 						{
 						case 0:
-							m_InEditorPlaying = true;
+							m_ToolbarDockSettings.m_InEditorPlaying = true;
 							m_StartPlayingScene = SceneLoader::GetSingleton()->getCurrentScene()->getScenePath();
 							EventManager::GetSingleton()->call(EditorEvents::EditorSaveAll);
 							EditorApplication::GetSingleton()->setGameMode(true);
@@ -75,13 +75,13 @@ void ToolbarDock::draw(float deltaMilliseconds)
 							PRINT("Loaded Scene in Editor");
 							break;
 						case 1:
-							m_InEditorPlaying = false;
+							m_ToolbarDockSettings.m_InEditorPlaying = false;
 							EventManager::GetSingleton()->call(EditorEvents::EditorSaveAll);
 							OS::RunApplication("\"" + OS::GetGameExecutablePath() + "\" " + SceneLoader::GetSingleton()->getCurrentScene()->getScenePath());
 							PRINT("Launched Game process with Scene");
 							break;
 						case 2:
-							m_InEditorPlaying = false;
+							m_ToolbarDockSettings.m_InEditorPlaying = false;
 							EventManager::GetSingleton()->call(EditorEvents::EditorSaveAll);
 							OS::RunApplication("\"" + OS::GetGameExecutablePath() + "\"");
 							PRINT("Launched Game process");

--- a/editor/gui/toolbar_dock.h
+++ b/editor/gui/toolbar_dock.h
@@ -13,13 +13,13 @@ public:
 	struct ToolbarDockSettings
 	{
 		bool m_IsActive = true;
+		bool m_InEditorPlaying = false;
 	};
 
 private:
 	ToolbarDockSettings m_ToolbarDockSettings;
 	Vector<float> m_FPSRecords;
 	unsigned int m_FPSRecordsPoolSize = 100;
-	bool m_InEditorPlaying = false;
 	String m_StartPlayingScene;
 
 	Variant disablePlayInEditor(const Event* e);


### PR DESCRIPTION
Autosave toggle checkbox added in Scene menu. Autosave is off when game plays in editor.
Fixes https://github.com/sdslabs/Rootex/issues/523