### PR TITLE
Fix: Disable Depth Stencil Test for Colliders

### DIFF
--- a/rootex/framework/components/physics/rigid_body_component.cpp
+++ b/rootex/framework/components/physics/rigid_body_component.cpp
@@ -3,6 +3,7 @@
 #include "common/types.h"
 
 #include "framework/systems/physics_system.h"
+#include "framework/systems/render_system.h"
 #include "script/script.h"
 
 #include "entity.h"
@@ -230,10 +231,12 @@ void RigidBodyComponent::setKinematic(bool enabled)
 
 void RigidBodyComponent::highlight()
 {
+	RenderSystem::GetSingleton()->enableSubmitLinesOnTop();
 	PhysicsSystem::GetSingleton()->debugDrawComponent(
 	    m_Body->getWorldTransform(),
 	    m_CollisionShape.get(),
 	    VecTobtVector3({ 0.8f, 0.1f, 0.1f }));
+	RenderSystem::GetSingleton()->disableSubmitLinesOnTop();
 }
 
 JSON::json RigidBodyComponent::getJSON() const

--- a/rootex/framework/systems/render_system.h
+++ b/rootex/framework/systems/render_system.h
@@ -32,6 +32,9 @@ class RenderSystem : public System
 
 	Ref<BasicMaterialResourceFile> m_LineMaterial;
 	LineRequests m_CurrentFrameLines;
+	LineRequests m_CurrentFrameLinesOnTop; // these lines will be rendered on top of everything else
+
+	bool m_SubmitLinesOnTop;
 
 	Microsoft::WRL::ComPtr<ID3D11Buffer> m_PerFrameVSCB;
 	Microsoft::WRL::ComPtr<ID3D11Buffer> m_PerCameraChangeVSCB;
@@ -56,6 +59,10 @@ public:
 	void setConfig(const SceneSettings& sceneSettings) override;
 	void update(float deltaMilliseconds) override;
 	void renderLines();
+	void renderLinesOnTop();
+
+	void enableSubmitLinesOnTop();
+	void disableSubmitLinesOnTop();
 
 	void submitLine(const Vector3& from, const Vector3& to);
 


### PR DESCRIPTION
Fixes #540.
Result:
![render_colliders_on_top](https://user-images.githubusercontent.com/26199781/168473565-26f9e57c-9778-428c-b8b4-69138e090596.png)

